### PR TITLE
Respect accessor specification.

### DIFF
--- a/gltf-json/src/accessor.rs
+++ b/gltf-json/src/accessor.rs
@@ -176,8 +176,9 @@ pub struct Accessor {
     pub buffer_view: Option<Index<buffer::View>>,
 
     /// The offset relative to the start of the parent `BufferView` in bytes.
-    #[serde(default, rename = "byteOffset")]
-    pub byte_offset: u32,
+    #[serde(rename = "byteOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_offset: Option<u32>,
 
     /// The number of components within the buffer view - not to be confused
     /// with the number of bytes in the buffer view.
@@ -230,9 +231,8 @@ impl Validate for Accessor {
         P: Fn() -> Path,
         R: FnMut(&dyn Fn() -> Path, Error),
     {
-        if self.sparse.is_none() && self.buffer_view.is_none() {
-            // If sparse is missing, then bufferView must be present. Report that bufferView is
-            // missing since it is the more common one to require.
+        if self.buffer_view.is_none() && self.byte_offset.is_some() {
+            // byteOffset MUST NOT be defined when bufferView is undefined.
             report(&|| path().field("bufferView"), Error::Missing);
         }
 

--- a/src/accessor/mod.rs
+++ b/src/accessor/mod.rs
@@ -120,7 +120,7 @@ impl<'a> Accessor<'a> {
 
     /// Returns the offset relative to the start of the parent buffer view in bytes.
     pub fn offset(&self) -> usize {
-        self.json.byte_offset as usize
+        self.json.byte_offset.unwrap_or(0) as usize
     }
 
     /// Returns the number of components within the buffer view - not to be confused


### PR DESCRIPTION
There were two things going against the spec.

1. The `Validate` implementation asserts `buffer_view` and `sparse`
must not both be empty, which is actually allowed.

2. The `Accessor` always has `byte_offset` even when `buffer_view`
is none, which is not allowed.